### PR TITLE
Change the kotlinx-serialization plugin

### DIFF
--- a/part-1-fundamentals/setting-up.md
+++ b/part-1-fundamentals/setting-up.md
@@ -30,7 +30,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
     val kotlinVersion: String by System.getProperties()
-    id("kotlinx-serialization") version kotlinVersion
+    kotlin("plugin.serialization") version kotlinVersion
     kotlin("js") version kotlinVersion
 }
 


### PR DESCRIPTION
As of 2021-04-25 it is accessible as `kotlin("plugin.serialization")`