### PR TITLE
Fix icons on tab panel labels

### DIFF
--- a/part-1-fundamentals/layout-containers.md
+++ b/part-1-fundamentals/layout-containers.md
@@ -86,13 +86,13 @@ This container creates a popular tabbed layout, with tabs on the top, left or ri
 
 ```kotlin
 tabPanel {
-    tab("Apple", "fas fa-apple") {
+    tab("Apple", "fab fa-apple") {
         div("Apple description")
     }
-    tab("Google", "fas fa-google") {
+    tab("Google", "fab fa-google") {
         div("Google description")
     }
-    tab("Microsoft", "fas fa-windows") {
+    tab("Microsoft", "fab fa-windows") {
         div("Microsoft description")
     }
 }


### PR DESCRIPTION
A tiny fix to make the FA icons on the tab panel labels work.