### PR TITLE
Clean up old commit + add Extending DSL section

### DIFF
--- a/part-1-fundamentals/basic-components.md
+++ b/part-1-fundamentals/basic-components.md
@@ -133,4 +133,38 @@ button(text = "X", classes = setOf("close")) {
 ```
 
 
+## Extending KVision DSL
+
+If you want to build custom DSL types, you can override existing types such as `div`. This might be useful if a certain custom component won't know their children ahead of time, for example, a "card" component that has a fancy border.
+
+Card type:
+
+```kotlin
+fun Container.card(
+    content: String? = null,
+    rich: Boolean = false,
+    align: Align? = null,
+    classes: Set<String>? = null,
+    className: String? = null,
+    init: (Div.() -> Unit)? = null
+): Div {
+    val div = Div(content, rich, align, setOf("fooCard"), init) // define css classname or other overrides here
+    this.add(div)
+    return div
+}
+```
+
+Usage:
+
+```kotlin
+card {
+    CustomComponent()
+}
+```
+
+
+
+
+
+
 

--- a/part-1-fundamentals/js-routing.md
+++ b/part-1-fundamentals/js-routing.md
@@ -62,6 +62,8 @@ routing.navigate("/foo")
 
 ### Hooks
 
+**Note**: Hooks are not fully support yet by Kvision
+
 [Hooks](https://github.com/krasimir/navigo/blob/master/DOCUMENTATION.md#hooks) are functions that are fired during the resolving process. There are four hooks that are fired:
 
 * before
@@ -69,15 +71,15 @@ routing.navigate("/foo")
 * leave
 * already
 
-You can override hooks for all routes
+You can override hooks for all routes, e.g.
 
 ```kotlin
 routing
     .hooks(object: RouteHooks {
         override var before: BeforeHook?
-                = { done: Function<*>, match: Match ->
+                = { done: dynamic, _: Match ->
             console.log("someBeforeHookLogic")
-            done() // Q: Invoke doesn't work for me, I might be missing something? 
+            done() 
         }
     })
     ...
@@ -95,20 +97,6 @@ routing
     ...
 ```
 
-
-### Rendering Components
-
-Render custom compoents
-
-```kotlin
-routing
-    ...
-    .on("/foo", {
-            SomeFooComponent()
-            h1("foo")
-        })
-    ...
-```
 
 ### Usage with Panel
 


### PR DESCRIPTION
Hi,

This PR removes some leftover comments I had on the [last PR](https://github.com/rjaros/kvision-guide/pull/9), applies the change that you mentioned with hooks, and removes the rendering components part ( I will get back in the future )

I also added a section about extending the kvision DSL. I used it to emulate similar behavior to containment [in react](https://reactjs.org/docs/composition-vs-inheritance.html)